### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,16 +6,16 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-PlainFFT KEYWORD1
+PlainFFT	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-complexToMagnitude KEYWORD2
-compute KEYWORD2
-windowing KEYWORD2
-exponent KEYWORD2
-swap KEYWORD2
-revision KEYWORD2
-majorPeak KEYWORD2
+complexToMagnitude	KEYWORD2
+compute	KEYWORD2
+windowing	KEYWORD2
+exponent	KEYWORD2
+swap	KEYWORD2
+revision	KEYWORD2
+majorPeak	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords