### PR TITLE
FFT_03.ino: fix micros() rollover issue and sampling frequency

### DIFF
--- a/Examples/FFT_03/FFT_03.ino
+++ b/Examples/FFT_03/FFT_03.ino
@@ -59,7 +59,7 @@ void loop()
 
       vReal[i] = analogRead(CHANNEL);
       vImag[i] = 0;
-      while(micros() < (microseconds + sampling_period_us)){
+      while(micros() - microseconds < sampling_period_us){
         //empty loop
       }
   }

--- a/Examples/FFT_03/FFT_03.ino
+++ b/Examples/FFT_03/FFT_03.ino
@@ -53,15 +53,15 @@ void setup()
 void loop()
 {
   /*SAMPLING*/
+  microseconds = micros();
   for(int i=0; i<samples; i++)
   {
-      microseconds = micros();    //Overflows after around 70 minutes!
-
       vReal[i] = analogRead(CHANNEL);
       vImag[i] = 0;
       while(micros() - microseconds < sampling_period_us){
         //empty loop
       }
+      microseconds += sampling_period_us;
   }
   /* Print the results of the sampling according to time */
   Serial.println("Data:");


### PR DESCRIPTION
The first commit in this pull request fixes the `micros()` rollover issue in FFT\_03.ino. The fix is pretty trivial: instead of comparing the timestamps `micros()` and `microseconds + sampling_period_us`, compare the durations `micros() - microseconds` and `sampling_period_us`. Unlike timestamps, [durations are safe to compare][rollover], even across rollover events. Thus:

```diff
 
       vReal[i] = analogRead(CHANNEL);
       vImag[i] = 0;
-      while(micros() < (microseconds + sampling_period_us)){
+      while(micros() - microseconds < sampling_period_us){
         //empty loop
       }
   }
```

The pull request also fixes a somewhat unrelated issue: The `micros()` counter can increment after the empty loop and before the statement `microseconds = micros();`, which will cause some timing drift. This means that `sampling_period_us` will be the _minimal_ rather than the _average_ period between samples. This is fixed in the second commit.

I can split this PR into two separate pull requests if you prefer.

The whole issue has been discussed in the Arduino StackExchange: [Getting FFT arduino code to run over 9+ hours, utilizing micros()][StackExchange].

[rollover]: https://arduino.stackexchange.com/q/12587
[StackExchange]: https://arduino.stackexchange.com/questions/56219