### PR TITLE
Fix DCRemoval(): average all samples in time

### DIFF
--- a/src/arduinoFFT.cpp
+++ b/src/arduinoFFT.cpp
@@ -199,13 +199,13 @@ void arduinoFFT::DCRemoval()
 {
 	// calculate the mean of vData
 	double mean = 0;
-	for (uint16_t i = 1; i < ((this->_samples >> 1) + 1); i++)
+	for (uint16_t i = 0; i < this->_samples; i++)
 	{
 		mean += this->_vReal[i];
 	}
 	mean /= this->_samples;
 	// Subtract the mean from vData
-	for (uint16_t i = 1; i < ((this->_samples >> 1) + 1); i++)
+	for (uint16_t i = 0; i < this->_samples; i++)
 	{
 		this->_vReal[i] -= mean;
 	}
@@ -216,13 +216,13 @@ void arduinoFFT::DCRemoval(double *vData, uint16_t samples)
 	// calculate the mean of vData
 	#warning("This method is deprecated and may be removed on future revisions.")
 	double mean = 0;
-	for (uint16_t i = 1; i < ((samples >> 1) + 1); i++)
+	for (uint16_t i = 0; i < samples; i++)
 	{
 		mean += vData[i];
 	}
 	mean /= samples;
 	// Subtract the mean from vData
-	for (uint16_t i = 1; i < ((samples >> 1) + 1); i++)
+	for (uint16_t i = 0; i < samples; i++)
 	{
 		vData[i] -= mean;
 	}


### PR DESCRIPTION
I was experimenting with audio signal input using ESP32. It required me to subtract the DC bias and perform FFT. When I was using DCRemoval(), I could see no change for the later half of the signal. Upon inspecting the function, I noticed half the samples weren't taken into consideration. 

Presently, `i` varies from `1` to `(N/2)`, where N is number of samples.
The commit in this pull request fixes that, and averaging occurs throughout all the samples.
That is, from `0` to `N-1`.

```diff
-	for (uint16_t i = 1; i < ((this->_samples >> 1) + 1); i++)
+	for (uint16_t i = 0; i < this->_samples; i++)
	{
		mean += this->_vReal[i];
	}
```