### PR TITLE
Make the sqrt_internal macro customisable

### DIFF
--- a/src/arduinoFFT.h
+++ b/src/arduinoFFT.h
@@ -50,7 +50,9 @@
 #ifdef FFT_SQRT_APPROXIMATION
 	#include <type_traits>
 #else
-	#define sqrt_internal sqrt
+	#ifndef sqrt_internal
+		#define sqrt_internal sqrt
+	#endif
 #endif
 
 enum class FFTDirection


### PR DESCRIPTION
Even though the develop branch allows specifying whether to use floats or doubles, it doesn't allow the same for the square root function. This pull request simply wraps the `sqrt_internal` define in an `ifndef`. This allows you to define a custom square root function, such as `sqrtf`, for use by the library.