### PR TITLE
Add CMakeList to use on Arduino as an ESP-IDF component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(src_dirs ./src)
+set(include_dirs ./src)
+idf_component_register(SRC_DIRS ${src_dirs} 
+                        INCLUDE_DIRS ${include_dirs})


### PR DESCRIPTION
# Add CMakeLists.txt for ESP32 Project using Arduino Framework inside ESP-IDF

## Summary
This pull request adds a `CMakeLists.txt` file to the project, enabling the use of this library in an ESP32 project using the Arduino framework within the ESP-IDF environment.

## Changes
- Added `CMakeLists.txt` to the root directory.

## Details
The `CMakeLists.txt` file is configured to integrate this library seamlessly with the ESP-IDF build system, allowing it to be used as a component in ESP32 projects that utilize the Arduino framework. This change ensures that the library can be easily included and compiled within the ESP-IDF environment.

## Notes
- Ensure that your ESP-IDF environment is set up correctly before using this library as a component.
- Refer to the updated documentation for instructions on how to include this library in your ESP-IDF project using the Arduino framework.
- For more information, see the [ESP-IDF Component documentation](https://docs.espressif.com/projects/arduino-esp32/en/latest/esp-idf_component.html#adding-local-library).
- As an example, you can refer to the [SensorLib CMakeLists.txt](https://github.com/lewisxhe/SensorLib/blob/master/CMakeLists.txt) for guidance on how to structure your CMakeLists file.
